### PR TITLE
rename module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mwitkow/grpc-proxy
+module github.com/smartcontractkit/grpc-proxy
 
 go 1.14
 

--- a/proxy/examples_test.go
+++ b/proxy/examples_test.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/mwitkow/grpc-proxy/proxy"
+	"github.com/smartcontractkit/grpc-proxy/proxy"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -22,8 +22,8 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	"github.com/mwitkow/grpc-proxy/proxy"
-	pb "github.com/mwitkow/grpc-proxy/testservice"
+	"github.com/smartcontractkit/grpc-proxy/proxy"
+	pb "github.com/smartcontractkit/grpc-proxy/testservice"
 )
 
 const (

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -11,8 +11,8 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/test/bufconn"
 
-	"github.com/mwitkow/grpc-proxy/proxy"
-	"github.com/mwitkow/grpc-proxy/testservice"
+	"github.com/smartcontractkit/grpc-proxy/proxy"
+	"github.com/smartcontractkit/grpc-proxy/testservice"
 )
 
 var testBackend = flag.String("test-backend", "", "Service providing TestServiceServer")

--- a/testservice/server/main.go
+++ b/testservice/server/main.go
@@ -11,7 +11,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/mwitkow/grpc-proxy/testservice"
+	"github.com/smartcontractkit/grpc-proxy/testservice"
 )
 
 var (

--- a/testservice/testping.go
+++ b/testservice/testping.go
@@ -99,7 +99,7 @@ func TestTestServiceServerImpl(t *testing.T, client TestServiceClient) {
 			}
 			res, err := stream.Recv()
 			if err != nil {
-				t.Errorf("receiving full duplex stream: %w", err)
+				t.Errorf("receiving full duplex stream: %v", err)
 				return
 			}
 			t.Logf("got %v (%d)", res.Value, res.Counter)


### PR DESCRIPTION
From `github.com/mwitkow/grpc-proxy` to `github.com/smartcontractkit/grpc-proxy`.